### PR TITLE
Remove coffee-script as a dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,5 @@
-require('coffee-script');
-module.exports = require('./lib/main');
+module.exports = function factorial(v) {
+  return v === 0
+    ? 1
+    : v * factorial(v - 1);
+};

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,0 @@
-factorial = (v) -> 
-  (if v is 0 then 1 else v*factorial(v-1))
-
-module.exports = factorial

--- a/package.json
+++ b/package.json
@@ -6,11 +6,9 @@
    "repository":"git://github.com/wearefractal/factorial.git",
    "author":"Fractal <contact@wearefractal.com> (http://wearefractal.com/)",
    "main":"./index.js",
-   
-   "dependencies":{
-      "coffee-script":"*"
-   },
+
    "devDependencies":{
+      "coffee-script": "*",
       "mocha":"*",
       "should":"*"
    },


### PR DESCRIPTION
It adds unnecessary bloat for such a small module. I'm fine with keeping it as a dev dependency for the tests though.
